### PR TITLE
Include babelify transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
     "coverage": "istanbul cover _mocha -- $npm_package_config_mocha",
     "style": "semistandard"
   },
+  "browserify": {
+    "transform": [
+      "babelify"
+    ]
+  },
   "config": {
     "mocha": "--reporter spec --ui bdd"
   },


### PR DESCRIPTION
Using this technique, the module is transpiled when used with browserify (if
the babelify transform is available). Otherwise the `const` keywords breaks
some browsers.